### PR TITLE
username is displayed at BOTTOM of page (not top)

### DIFF
--- a/app/views/articles/share.html.haml
+++ b/app/views/articles/share.html.haml
@@ -15,7 +15,7 @@
   %p
     Be sure to note that when someone views a Practicing Ruby article via
     a share link you created, your github username will be displayed at the
-    top of the page so that they know who to thank! Of course, no one except
+    bottom of the page so that they know who to thank! Of course, no one except
     those who receive your link will know about your act of kindness, so
     those who prefer to keep a gruff public persona can still use this
     feature in private.


### PR DESCRIPTION
fix text describing where username will show up when sharing an article
