### PR TITLE
Let our subscribers know that GitHub sometimes sucks

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -31,5 +31,9 @@ class SessionsController < ApplicationController
     session.delete("authorization_id")
     redirect_to "/"
   end
+  
+  def failure
+    @message = params[:message].humanize if params[:message]
+  end
 
 end

--- a/app/views/sessions/failure.html.haml
+++ b/app/views/sessions/failure.html.haml
@@ -1,0 +1,14 @@
+- content_for(:title) { "GitHub is broken"}
+- content_for(:header) { "GitHub is broken#{': ' + @message if @message}" }
+
+%h3
+  Sorry but you can't sign in right now because of problems with GitHub
+%p
+  Check out 
+  #{link_to "GitHub's status page", "http://status.github.com"} for the most
+  up-to-date information and 
+  = mail_to "support@elmcitycraftworks.org", "contact us", 
+    :subject => "GitHub is down and I can't sign in :("
+  if the problem persists.
+
+= render "shared/sad_pinkie"

--- a/app/views/shared/_sad_pinkie.html.haml
+++ b/app/views/shared/_sad_pinkie.html.haml
@@ -1,0 +1,3 @@
+= image_tag "sad_pinkie.png", :class => "sad_pinkie",
+  :title => "Sad Pinkie: http://regolithx.deviantart.com/art/Sad-Pinkie-Pie-Vector-285845297"
+// Image Credit: http://regolithx.deviantart.com/art/Sad-Pinkie-Pie-Vector-285845297

--- a/app/views/users/destroy.html.haml
+++ b/app/views/users/destroy.html.haml
@@ -7,6 +7,4 @@
 %p
   And remember it may take up to 24 hours before your account is fully cancelled.
 
-= image_tag "sad_pinkie.png", :class => "sad_pinkie",
-  :title => "Sad Pinkie: http://regolithx.deviantart.com/art/Sad-Pinkie-Pie-Vector-285845297"
-// Image Credit: http://regolithx.deviantart.com/art/Sad-Pinkie-Pie-Vector-285845297
+= render "shared/sad_pinkie"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ PracticingRubyWeb::Application.routes.draw do
 
   match '/sessions/link/:secret' => 'sessions#link'
   match '/auth/github/callback'  => 'sessions#create'
+  match '/auth/failure'          => 'sessions#failure'
   match '/logout'                => 'sessions#destroy', :as => 'logout'
   match '/login'                 => 'sessions#new',     :as => 'login'
 


### PR DESCRIPTION
If you like what you see, feel free to merge it into master. Since GitHub's oAuth server is down right now I'm deploying this via an integration branch `nudge-auth-failure`. Before this fix users were sent to a 404 page with no explanation as to what happened when they tried signing in. Also I :heart: :octocat:
## [Do it live](https://practicingruby.com/auth/failure?message=timeout)

![Screen shot 2012-12-11 at 6 34 38 PM](https://f.cloud.github.com/assets/40662/7132/6f840ef4-43eb-11e2-9be8-b455acc7e348.png)
