### PR TITLE
Fix image overhang

### DIFF
--- a/app/assets/stylesheets/partials/_mixins.sass
+++ b/app/assets/stylesheets/partials/_mixins.sass
@@ -107,7 +107,7 @@ $green: #3D6E3C
     +image-box
     margin: 0 auto
     display: block
-    max-width: 750px
+    max-width: 740px 
     &.emoji
       padding: 0
       border: none


### PR DESCRIPTION
Prevents images and videos from hanging off the right side of the column in article view.
