### PR TITLE
Run whenever via bundle exec

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,6 +16,7 @@ set :branch, $1 if `git branch` =~ /\* (\S+)\s/m
 set :use_sudo, false
 set :deploy_via, :remote_cache
 
+set :whenever_command, "bundle exec whenever"
 set :whenever_identifier, defer { application }
 
 set :maintenance_template_path, 'app/views/layouts/maintenance.html.erb'


### PR DESCRIPTION
Fixes this problem:

```
  * 2013-10-07 14:54:38 executing `whenever:clear_crontab'
  * executing "cd /home/deploy/releases/20131007125144 && whenever --clear-crontab practicing-ruby"
    servers: ["practicingruby.local"]
    [practicingruby.local] executing command
*** [err :: practicingruby.local] sh: 1:
*** [err :: practicingruby.local] whenever: not found
*** [err :: practicingruby.local]
    command finished in 6ms
*** [deploy:update_code] rolling back
  * executing "rm -rf /home/deploy/releases/20131007125144; true"
    servers: ["practicingruby.local"]
    [practicingruby.local] executing command
    command finished in 20ms
failed: "env PATH=/opt/rubies/2.0.0-p247/bin:$PATH sh -c 'cd /home/deploy/releases/20131007125144 && whenever --clear-crontab practicing-ruby'" on practicingruby.local
```
