### PR TITLE
Remove PATH hack from Vagrant deploy config

### DIFF
--- a/config/deploy/vagrant.rb
+++ b/config/deploy/vagrant.rb
@@ -11,9 +11,6 @@ set :user, "deploy"
 # Only production is supported at the moment
 set :rails_env, "production"
 
-# Use Ruby version installed by chruby
-set :default_environment, { "PATH" => "/opt/rubies/2.0.0-p247/bin:$PATH" }
-
 # Set custom hostname to connect to Vagrant VM
 server "practicingruby.local", :app, :web, :db, :primary => true
 


### PR DESCRIPTION
Now that https://github.com/elm-city-craftworks/practicing-ruby-cookbook/pull/9 was merged, we no longer need to set `PATH`.
