### PR TITLE
Skip Stripe-related tests if no API key is provided

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -61,3 +61,8 @@ end
 def skip_on_travis
   skip "Do not run this test on travis ci" if ENV["TRAVIS"]
 end
+
+def skip_if_no_stripe_key
+  skip "Do not run this test if no Stripe API key set" if ENV["STRIPE_SECRET_KEY"] == "stripe-secret"
+end
+

--- a/test/unit/stripe/payment_gateway_test.rb
+++ b/test/unit/stripe/payment_gateway_test.rb
@@ -17,6 +17,7 @@ class StripePaymentGatewayTest < ActiveSupport::TestCase
 
   test 'subscribe (success)' do
     skip_on_travis
+    skip_if_no_stripe_key
 
     refute @user.subscriptions.active,
            "Should not have an active subscription before payment"
@@ -36,6 +37,7 @@ class StripePaymentGatewayTest < ActiveSupport::TestCase
 
   test 'subscribe (failure)' do
     skip_on_travis
+    skip_if_no_stripe_key
 
     refute @user.subscriptions.active,
            "Should not have an active subscription before payment"


### PR DESCRIPTION
Implements a new test_helper method, skip_if_no_stripe_key, which
works as per skip_on_travis but checks for the presence of
STRIPE_SECRET_KEY in ENV.

This commit also adds code to use this new test_helper method in
the two Stripe-related tests.
