### PR TITLE
to fix bundle exec rake setup

### DIFF
--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -1,4 +1,5 @@
 require 'rails_setup'
+require 'rainbow/ext/string'
 
 namespace :setup do
   desc 'Create .env file from .env.example'


### PR DESCRIPTION
Working using ruby 2.1.1. After bundle install, then I run bundle exec rake setup, and I have the following errors:

```
➜  practicing-ruby-web git:(master) bundle exec rake setup

rake aborted!
undefined method `color' for "♥ ":String
/home/david/.rvm/gems/ruby-2.1.1/gems/rails_setup-0.0.3/lib/rails_setup/environment.rb:17:in `heart'
/home/david/gitrepos/practicing-ruby-web/lib/tasks/setup.rake:15:in `block in <top (required)>
```

According to README.md in rainbow, we should use require 'rainbow/ext/string'  for following code in rails_setup

``` ruby
 "\u2665 ".color(:red)

```
