### PR TITLE
Add whitespace to rails_security_workarounds.rb

### DIFF
--- a/config/initializers/rails_security_workarounds.rb
+++ b/config/initializers/rails_security_workarounds.rb
@@ -7,7 +7,9 @@ ActiveSupport::XmlMini.backend = 'Nokogiri'
 module ActiveSupport
   module JSON
     module Encoding
+      
       private
+      
       class EscapedString
         def to_s
           self


### PR DESCRIPTION
Previously rubocop flagged this file due to a whitespace violation "Keep a blank line before and after private". This patch satisfies that code style rule.
